### PR TITLE
Updated to be used as a module inside an existing express app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.log
+nbproject

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ app - Express app instance.
 * GET
 
   Put your json file inside service folder in same structure as of your request URL
-e.g: ``/profile/1234`` would be service / stubService / profile (folder) / 1234.json
+e.g: ``stubService/profile/1234`` would be service / stubService / profile (folder) / 1234.json
 You don't need to restart the app
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Node Mock REST App
 
 ### Description
-This application gives your project easy setup for mock services.
+This application gives your project easy setup for mock services. It can be run as a standalone NodeJS server to serve stub responses.
+If you already have an express app running, you can include this module and invoke startMock function to start the stub services.
 
 Blog Post: [Novice Lab](http://novicelab.org/project/stub-services-runner-in-node-js/535/)
 
@@ -12,22 +13,30 @@ Blog Post: [Novice Lab](http://novicelab.org/project/stub-services-runner-in-nod
 ### Pre Requisite
 * Node JS
 
-### Starting the app
+### Starting the standalone app
 * Run ``npm start``
-* App would run on ``localhost:3333``
+* App would run on ``localhost:6174``
 * If you want to run on different port run ``PORT=<new_port> npm start``
+
+### Adding to your Express App
+var nodeMock = require('node-mock-rest');
+nodeMock.startMock(config, app);
+
+config - JSON object for the application config. It can be used to specify the path (relative to node process) of the stub service directory present in your express app.
+e.g. config = {stub_dir: 'stubs'}
+app - Express app instance.
 
 ### How to use
 * GET
 
   Put your json file inside service folder in same structure as of your request URL
-e.g: ``/profile/1234`` would be service / profile (folder) / 1234.json
+e.g: ``/profile/1234`` would be service / stubService / profile (folder) / 1234.json
 You don't need to restart the app
 
 
 * POST
 
-  Data in request body will be written to the file mentioned in the POST url. For e.g.: ``/profile/1234`` would create a file ``1234.json`` inside ``profile`` folder and write the request body to it. By default, the response would be a success. However, if you need a custom response, create a file ``postresp/1234.json``
+  Data in request body will be written to the file mentioned in the POST url. For e.g.: ``stubService/profile/1234`` would create a file ``1234.json`` inside ``profile`` folder and write the request body to it. By default, the response would be a success. However, if you need a custom response, create a file ``postresp/1234.json``
 
 
 * Other Requests

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	server_port: 6174,
+	stub_dir: service
+}

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	server_port: 6174,
-	stub_dir: service
+	stub_dir: 'service'
 }

--- a/index.js
+++ b/index.js
@@ -1,136 +1,158 @@
 /*jshint node: true*/
 
+/* global exports, module, __dirname, process */
+
 /**
  * Index.js
  * Creates an express app to manage mock response
  */
 
 var express = require('express'),
-  fs = require('fs'),
-  path = require('path'),
-  bodyParser = require('body-parser');
+        fs = require('fs'),
+        path = require('path'),
+        bodyParser = require('body-parser');
 
 var defaultConfig = require('./config');
 var constants = require('./constants.json');
 var _ = require('lodash');
 
-module.exports = function(config, app){
-    if (!app) {
-      // merge the config with the default config
-      config = _.merge(defaultConfig, config);
-      console.log(config);
-      createApp(config);
+(function () {
+    var node_rest_mock = {};
+
+    exports.startMock = node_rest_mock.startMock = function (config, app) {
+        if (!app) {
+            app = createApp();
+        }
+        // merge the config with the default config
+        config = _.merge(defaultConfig, config);
+
+        addGETStubs(config, app);
+        addPOSTStubs(config, app);
+        catchAll(app);
+        start(config, app);
+    };
+    if (!module.parent) {
+        node_rest_mock.startMock();
     }
-}
+})();
 
 function addGETStubs(config, app) {
-  app.get('*', function (req, res) {
-    try {
-      var call_param = req.params[0];
-      // Send file content as response
-      res.setHeader('Content-Type', 'application/json');
-      res.sendFile(__dirname + config.stub_dir + call_param + '.json', {}, function (err) {
-      res.status(404).end(JSON.stringify(constants.ERR.File_Not_Found));
-      });
-    } catch (ex) {
-      res.status(404).end(ex.message);
-    }
-  });
-}
 
-function addPOSTStubs(app) {
-  app.post('*', function (req, res) {
-  var path, respPath, x, y;
-  try {
-    var call_param = req.params[0];
-
-    path = __dirname + config.stub_dir + call_param + '.json';
-
-    /** finds the response path*/
-    x = call_param.split('/');
-    x[x.length - 1] = 'postresp/' + x[x.length - 1];
-    respPath = __dirname + '/service' + x.join('/') + '.json';
-
-    // Writes the request body to the file
-    fs.writeFile(path, JSON.stringify(req.body), function (err) {
-      if (err) {
-        // NodeJS can create a file, it needs the directory to be present
-        if (err.code === 'ENOENT') {
-          res.status(500).end(JSON.stringify(constants.ERR.ENOENT));
-        } else {
-          res.status(500).end(err.toString());
-        }
-      } else {
-        fs.exists(respPath, function (exists) {
-          if (exists) {
-            // If response path exists, send file as response
-            res.sendFile(respPath, {}, function (err) {
-              res.status(404).end(JSON.stringify(constants.ERR.File_Not_Found));
+    app.get('*', function (req, res) {
+        try {
+            var call_param = req.params[0];
+            // Send file content as response
+            res.setHeader('Content-Type', 'application/json');
+            res.sendFile(__dirname + path.sep + config.stub_dir + call_param + '.json', {}, function (err) {
+                res.status(404).end(JSON.stringify(constants.ERR.File_Not_Found));
             });
-          } else {
-            // If reponse path doesn't exists, send success response
-            res.status(200).end(JSON.stringify(constants.SUCCESS));
-          }
-        });
-      }
+        } catch (ex) {
+            res.status(404).end(ex.message);
+        }
     });
-  } catch (ex) {
-    res.status(404).end(ex.message);
-  }
-});
 }
 
-function createApp(config) {
+function addPOSTStubs(config, app) {
 
-  // Creates express app
-var app = express();
+    app.post('*', function (req, res) {
+        var path, respPath, x, y;
+        try {
+            var call_param = req.params[0];
 
-// parse application/x-www-form-urlencoded 
-app.use(bodyParser.urlencoded({
-  extended: false
-}));
+            path = __dirname + path.sep + config.stub_dir + call_param + '.json';
 
-// parse application/json 
-app.use(bodyParser.json());
+            /** finds the response path*/
+            x = call_param.split('/');
+            x[x.length - 1] = 'postresp/' + x[x.length - 1];
+            respPath = __dirname + '/service' + x.join('/') + '.json';
 
-/**
- * Allows access to all origin
- */
-app.all("*", function (req, res, next) {
-
-  // Specify the origin if you want to control the CORS origin
-  res.header('Access-Control-Allow-Origin', '*');
-
-  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
-
-  // Uncomment to allow with credentials. You'd need to give specific origin in that case
-  //res.header('Access-Control-Allow-Credentials', true);
-  next();
-});
-
-/**
- * Sucess response for all non GET requests
- */
-app.all('*', function (req, res) {
-  try {
-    res.status(200).end(JSON.stringify(constants.SUCCESS));
-  } catch (ex) {
-    res.status(404).end(ex.message);
-  }
-});
-
-// Run the application on the port 
-var port = config.server_port;
-if (app.get('env')) {
-  port = process.env.PORT || config.server_port;
+            // Writes the request body to the file
+            fs.writeFile(path, JSON.stringify(req.body), function (err) {
+                if (err) {
+                    // NodeJS can create a file, it needs the directory to be present
+                    if (err.code === 'ENOENT') {
+                        res.status(500).end(JSON.stringify(constants.ERR.ENOENT));
+                    } else {
+                        res.status(500).end(err.toString());
+                    }
+                } else {
+                    fs.exists(respPath, function (exists) {
+                        if (exists) {
+                            // If response path exists, send file as response
+                            res.sendFile(respPath, {}, function (err) {
+                                res.status(404).end(JSON.stringify(constants.ERR.File_Not_Found));
+                            });
+                        } else {
+                            // If reponse path doesn't exists, send success response
+                            res.status(200).end(JSON.stringify(constants.SUCCESS));
+                        }
+                    });
+                }
+            });
+        } catch (ex) {
+            res.status(404).end(ex.message);
+        }
+    });
 }
+
+function start(config, app) {
+    // Run the application on the port 
+    var port = config.server_port;
+    if (app.get('env')) {
+        port = process.env.PORT || config.server_port;
+    }
 
 // Starts the app
-app.listen(port, function () {
-  console.log('App Started at port number ' + port);
-});
+    app.listen(port, function () {
+        console.log('App Started at port number ' + port);
+    });
 
 }
 
+function createApp() {
+
+    // Creates express app
+    var app = express();
+
+// parse application/x-www-form-urlencoded 
+    app.use(bodyParser.urlencoded({
+        extended: false
+    }));
+
+// parse application/json 
+    app.use(bodyParser.json());
+
+    /**
+     * Allows access to all origin
+     */
+    app.all("*", function (req, res, next) {
+
+        // Specify the origin if you want to control the CORS origin
+        res.header('Access-Control-Allow-Origin', '*');
+
+        res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+
+        res.header('Access-Control-Allow-Headers', 'Content-Type');
+
+        // Uncomment to allow with credentials. You'd need to give specific origin in that case
+        //res.header('Access-Control-Allow-Credentials', true);
+        next();
+    });
+
+    return app;
+}
+
+/**
+ * Sucess response for all other requests
+ * @param {Express} app Express App
+ */
+function catchAll(app) {
+
+    app.all('*', function (req, res) {
+        try {
+            res.status(200).end(JSON.stringify(constants.SUCCESS));
+        } catch (ex) {
+            res.status(404).end(ex.message);
+        }
+    });
+}

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.13.1",
-    "express": "^4.12.2"
+    "express": "^4.12.2",
+    "lodash": "4.7.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ShivrajRath/Node-Mock-REST.git"
+    "url": "https://github.com/abhishekbhardwaj84/Node-Mock-REST.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/abhishekbhardwaj84/Node-Mock-REST.git"
+    "url": "https://github.com/ShivrajRath/Node-Mock-REST.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mock-rest",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Application to host mock JSON REST services for your project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This module can now be run standalone as well as part of an existing app. It expects the express 'app' and a JSON 'config' object in the input to start stub services. The config object should specify the stub dir path relative to the node process path.
